### PR TITLE
Fixes broken image SRC where name != URL

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,9 @@ import './App.css';
 
 function App() {
 
-  const BASE_URL = 'http://54.78.155.180:1337/'
-  const LANDING_PAGE_URI = 'landing-page'
-  const EVENTS_URI = 'events'
+  const BASE_URL = 'http://54.78.155.180:1337'
+  const LANDING_PAGE_URI = '/landing-page'
+  const EVENTS_URI = '/events'
 
   const [headerText, setHeaderText] = useState("");
   const [bodyText, setBodyText] = useState("");
@@ -32,7 +32,7 @@ function App() {
 
   const eventNodes = events.map(event => {
     return (
-      <Card key={event.id} title={event.title} body={event.body} image={event.image.name}/>
+      <Card key={event.id} title={event.title} body={event.body} image={BASE_URL + event.image.url}/>
     )
   })
 

--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,9 @@ import './App.css';
 
 function App() {
 
-  const LANDING_PAGE_URL = 'http://54.78.155.180:1337/landing-page'
-  const EVENTS_URL = 'http://54.78.155.180:1337/events'
+  const BASE_URL = 'http://54.78.155.180:1337/'
+  const LANDING_PAGE_URI = 'landing-page'
+  const EVENTS_URI = 'events'
 
   const [headerText, setHeaderText] = useState("");
   const [bodyText, setBodyText] = useState("");
@@ -17,7 +18,7 @@ function App() {
 
   useEffect(() => {
     // fetch from strapi
-    fetch(LANDING_PAGE_URL).then(res => res.json())
+    fetch(BASE_URL + LANDING_PAGE_URI).then(res => res.json())
     .then( data => {
       // set data from strapi to state vars
       setHeaderText(data.title);
@@ -25,7 +26,7 @@ function App() {
       setImageUrl(data.logo.name)
     })
 
-    fetch(EVENTS_URL).then(res => res.json())
+    fetch(BASE_URL + EVENTS_URI).then(res => res.json())
       .then(data => setEvents(data))
   }, []);
 


### PR DESCRIPTION
**Problem**: some of the images as pulled from Events were broken.

**Diagnosis**: Some of the image names were the same as the URL and I had assumed this was true for all of them... this assumption turned out to be false

**Solution**: Construct the Card's image `src` attribute from a shared `BASE_URL`.

Also using said `BASE_URL` to construct the URLs for fetching.