### PR TITLE
Generic content page 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import About from "./components/about";
 import HowPage from "./components/how";
 import CommunityPage from "./components/community";
 import Contact from "./components/contact";
+import GenericContentPage from './components/genericcontentpage/GenericContentPage';
 
 //refactor
 //pull data as needed perhaps on first call of page?
@@ -112,6 +113,7 @@ const contactProps = data;
         <Switch>
             <Route exact path="/" render={() => ( <HomePage homePageProps={homeProps} classname="main" /> )}/>
             <Route path="/about-page" render={() =>  <About aboutProps={aboutProps} sideMenu={subMenu} styleName="main" /> }/>
+            <Route path="/how-to/:slugField" render={routeProps => <GenericContentPage {...routeProps}/>}/>
             <Route path="/how-to" render={() =>  <HowPage howProps={howProps} styleName="main"/> }/>
             <Route path="/community" render={() =>  <CommunityPage communityProps={communityProps} styleName="main"/> }/>
             <Route path="/contact-us" render={() =>  <Contact contactProps={contactProps} styleName="main"/> }/>

--- a/src/components/genericcontentpage/GenericContentPage.js
+++ b/src/components/genericcontentpage/GenericContentPage.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+import useOukapi from '../../helpers/dataFetch';
+import HtmlSection from '../htmlsection';
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const GenericContentPage = ({match}) => {
+  const {slugField} = match.params;
+
+  const [{ data, isError }] = useOukapi(`${BASE_URL}/pages?slugfield=${slugField}`);
+
+  if (isError || !data[0]) return <h1>404 - content not found!</h1>;
+  const {page} = data[0];
+
+  return (
+    <main className="main">
+      <h1>{page.title}</h1>
+      <HtmlSection sections={page.sections} />
+    </main>
+  )
+}
+
+export default GenericContentPage;


### PR DESCRIPTION
This PR:

- creates a generic content page component
- renders these pages on "how-to/`some-slug-go-here`" route


... did this after a long week so I very much appreciate that it's not complete / might need a second set of eyes! I also don't mind if this doesn't get merged, but I think it's a step in the right direction ☺️

## Screenshots
Check the URLs + rendered content in the below screenshots:

![image](https://user-images.githubusercontent.com/20354076/115054579-499bbd80-9ed8-11eb-9d77-749d59b528e0.png)

---

![image](https://user-images.githubusercontent.com/20354076/115054678-6afca980-9ed8-11eb-9fa8-bd00a8315e5e.png)

---

![image](https://user-images.githubusercontent.com/20354076/115054762-81a30080-9ed8-11eb-992a-2337e92b0ef6.png)

