### PR TITLE
Generic content page now displays sidebar

### DIFF
--- a/src/components/genericcontentpage/GenericContentPage.js
+++ b/src/components/genericcontentpage/GenericContentPage.js
@@ -1,29 +1,48 @@
+import { useState, useEffect } from 'react';
 import useOukapi from '../../helpers/dataFetch';
 import HtmlSection from '../htmlsection';
-import {Link} from 'react-router-dom';
+import SideMenu from '../sidemenu';
+import { Link } from 'react-router-dom';
 const BASE_URL = process.env.REACT_APP_BASE_URL;
 
-const GenericContentPage = ({match}) => {
-  const {slugField} = match.params;
-console.log(BASE_URL);
-  const [{ data, isError }] = useOukapi(new URL('/pages?slugfield='+slugField, BASE_URL).href);
+const GenericContentPage = ({ match }) => {
+  const { slugField } = match.params;
+  const [{ data, isError }] = useOukapi(new URL('/pages?slugfield=' + slugField, BASE_URL).href);
+  const [page, setPage] = useState(null);
 
-  if (isError || !data[0]) return <h1>404 - content not found!</h1>;
-  const {page} = data[0];
+  const [sectionHeadings, setSectionHeadings] = useState([]);
+
+  useEffect(() => {
+    if (data[0]) {
+      setPage(data[0].page)
+    };
+
+    if (page) {
+      setSectionHeadings(page.sections.map(section => section.sectionHeading));
+    }
+
+  }, [page, data]);
+
+  if (isError || !data[0] || !page) return <h1>404 - content not found!</h1>;
 
   let readNextLink = <></>
-  if (page.ReadNextLink){
-    readNextLink = (<><hr/>
-    <Link to={page.ReadNextLink.url}>
-								{page.ReadNextLink.TextToDisplay}
-							</Link></>)
+  if (page.ReadNextLink) {
+    readNextLink = (<><hr />
+      <Link to={page.ReadNextLink.url}>
+        {page.ReadNextLink.TextToDisplay}
+      </Link></>)
   }
 
   return (
     <main className="main">
       <h1>{page.title}</h1>
-      <HtmlSection sections={page.sections} />
-      {readNextLink}
+      <div className="flexcontainer">
+        <SideMenu subMenu={sectionHeadings} />
+        <div className="flexright">
+          <HtmlSection sections={page.sections} />
+          {readNextLink}
+        </div>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
I hadn't fully realised that displaying the sidebar on the **Step by step guide on how to adopt the standard** page was going to mean changing the generic content page, but of course it did! I think this is a good thing as now each "generic content page" should in theory have a sidebar by default.

Any content pages using the generic content page (for now, `how-it-works/whats-in-the-standard` and `/how-it-works/step-by-step-guide-on-how-to-adopt-the-standard`) should render a sidebar:

![image](https://user-images.githubusercontent.com/20354076/115393611-cfba4b80-a1d9-11eb-85f2-e7306deffbfb.png)

![image](https://user-images.githubusercontent.com/20354076/115393655-d8128680-a1d9-11eb-91f7-2d2bfffad0a6.png)
@kingdomlevel I believe this is the one we agreed we will test and discuss before merging?