### PR TITLE
Renders case studies to front end app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import CommunityPage from "./components/community";
 import Contact from "./components/contact";
 import GenericContentPage from './components/genericcontentpage/GenericContentPage';
 import CaseStudiesLandingPage from './components/casestudies/LandingPage';
+import CaseStudy from "./components/casestudies/CaseStudy";
 
 //refactor
 //pull data as needed perhaps on first call of page?
@@ -108,6 +109,7 @@ const footerProps = data;
             <Route path="/about-open-referral" render={() =>  <About aboutProps={aboutProps} sideMenu={subMenu} styleName="main" /> }/>
             <Route path="/how-it-works/:slugField" render={routeProps => <GenericContentPage {...routeProps}/>}/>
             <Route path="/how-it-works" render={() =>  <HowPage styleName="main"/> }/>
+            <Route path="/community/case-studies/:slugField" render={routeProps => <CaseStudy {...routeProps} /> } />
             <Route path="/community/case-studies" render={ () => <CaseStudiesLandingPage styleName="main"/> } />
             <Route path="/community" render={() =>  <CommunityPage communityProps={communityProps} styleName="main"/> }/>
             <Route path="/contact-us" render={() =>  <Contact contactProps={contactProps} styleName="main"/> }/>

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import HowPage from "./components/how";
 import CommunityPage from "./components/community";
 import Contact from "./components/contact";
 import GenericContentPage from './components/genericcontentpage/GenericContentPage';
+import CaseStudiesLandingPage from './components/casestudies/LandingPage';
 
 //refactor
 //pull data as needed perhaps on first call of page?
@@ -105,8 +106,9 @@ const footerProps = data;
         <Switch>
             <Route exact path="/" render={() => ( <HomePage homePageProps={homeProps} classname="main" /> )}/>
             <Route path="/about-open-referral" render={() =>  <About aboutProps={aboutProps} sideMenu={subMenu} styleName="main" /> }/>
-			<Route path="/how-it-works/:slugField" render={routeProps => <GenericContentPage {...routeProps}/>}/>
-            <Route path="/how-it-works" render={() =>  <HowPage styleName="main"/> }/>			
+            <Route path="/how-it-works/:slugField" render={routeProps => <GenericContentPage {...routeProps}/>}/>
+            <Route path="/how-it-works" render={() =>  <HowPage styleName="main"/> }/>
+            <Route path="/community/case-studies" render={ () => <CaseStudiesLandingPage styleName="main"/> } />
             <Route path="/community" render={() =>  <CommunityPage communityProps={communityProps} styleName="main"/> }/>
             <Route path="/contact-us" render={() =>  <Contact contactProps={contactProps} styleName="main"/> }/>
       </Switch> 

--- a/src/components/casestudies/CaseStudy.js
+++ b/src/components/casestudies/CaseStudy.js
@@ -1,0 +1,29 @@
+import useOukapi from '../../helpers/dataFetch';
+import HtmlSection from '../htmlsection';
+import { Link } from 'react-router-dom';
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const CaseStudy = ({match}) => {
+  const { slugField } = match.params;
+  const [{ data, isError }] = useOukapi(new URL('/case-studies?slugfield=' + slugField, BASE_URL).href);
+
+  if (isError || !data[0]) return <h1>404 - content not found!</h1>;
+  const { title, sections, ReadNextLink } = data[0].CaseStudy;
+  let readNextLink = null;
+  if (ReadNextLink) {
+    readNextLink = (<><hr />
+      <Link to={ReadNextLink.url}>
+        {ReadNextLink.TextToDisplay}
+      </Link></>)
+  }
+
+  return (
+    <main className="main">
+      <h1>{title}</h1>
+      <HtmlSection sections={sections} />
+      {ReadNextLink}
+    </main>
+  )
+}
+
+export default CaseStudy;

--- a/src/components/casestudies/CaseStudy.js
+++ b/src/components/casestudies/CaseStudy.js
@@ -21,7 +21,7 @@ const CaseStudy = ({match}) => {
     <main className="main">
       <h1>{title}</h1>
       <HtmlSection sections={sections} />
-      {ReadNextLink}
+      {readNextLink}
     </main>
   )
 }

--- a/src/components/casestudies/CaseStudy.js
+++ b/src/components/casestudies/CaseStudy.js
@@ -1,11 +1,22 @@
+import { useState, useEffect } from 'react';
 import useOukapi from '../../helpers/dataFetch';
 import HtmlSection from '../htmlsection';
+import SideMenu from '../sidemenu';
 import { Link } from 'react-router-dom';
 const BASE_URL = process.env.REACT_APP_BASE_URL;
 
-const CaseStudy = ({match}) => {
+const CaseStudy = ({ match }) => {
+  const [sectionHeadings, setSectionHeadings] = useState([]);
+
   const { slugField } = match.params;
   const [{ data, isError }] = useOukapi(new URL('/case-studies?slugfield=' + slugField, BASE_URL).href);
+
+  useEffect(() => {
+    if (data[0] && data[0].CaseStudy && data[0].CaseStudy.sections) {
+      setSectionHeadings(data[0].CaseStudy.sections.map(section => section.sectionHeading));
+    }
+
+  }, [data]);
 
   if (isError || !data[0]) return <h1>404 - content not found!</h1>;
   const { title, sections, ReadNextLink } = data[0].CaseStudy;
@@ -20,8 +31,13 @@ const CaseStudy = ({match}) => {
   return (
     <main className="main">
       <h1>{title}</h1>
-      <HtmlSection sections={sections} />
-      {readNextLink}
+      <div className="flexcontainer">
+        <SideMenu subMenu={sectionHeadings} />
+        <div className="flexright">
+          <HtmlSection sections={sections} />
+          {readNextLink}
+        </div>
+      </div>
     </main>
   )
 }

--- a/src/components/casestudies/CaseStudyOverview.js
+++ b/src/components/casestudies/CaseStudyOverview.js
@@ -1,0 +1,16 @@
+import {Link} from "react-router-dom";
+
+const CaseStudyOverview = ({CaseStudy, description, slugfield}) => {
+  const {title} = CaseStudy;
+
+  return (
+    <Link to={`case-studies/${slugfield}`}>
+      <li className="case-study-overview listbox">
+        <h2>{title}</h2>
+        <p className="case-study-description">{description}</p>
+      </li>
+    </Link>
+  )
+};
+
+export default CaseStudyOverview;

--- a/src/components/casestudies/LandingPage.js
+++ b/src/components/casestudies/LandingPage.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import ContentPage from '../page'
+import useOukapi from '../../helpers/dataFetch';
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+const CASE_STUDIES_LANDING_PAGE = process.env.REACT_APP_CASE_STUDIES_LANDING_PAGE;
+
+const CaseStudiesLandingPage = ({styleName}) => {
+  const [title, setTitle] = useState("");
+  const [introParagraph, setIntroParagraph] = useState("");
+
+  const [{data}, isError] = useOukapi(new URL(CASE_STUDIES_LANDING_PAGE, BASE_URL).href);
+
+  useEffect(() => {
+    if (data.hasOwnProperty("title") && data.hasOwnProperty("introParagraph") ) {
+      setTitle(data.title);
+      setIntroParagraph(data.introParagraph)
+    }
+  }, [data]);
+  
+  if (isError || !data) return <h1>404 - content not found!</h1>;
+
+  return (
+    <main className={styleName}>
+      <ContentPage title={`<h1>${title}</h1>`} introParagraph={introParagraph} />
+    </main>
+  )
+}
+
+export default CaseStudiesLandingPage;

--- a/src/components/casestudies/LandingPage.js
+++ b/src/components/casestudies/LandingPage.js
@@ -1,14 +1,18 @@
 import { useState, useEffect } from 'react';
 import ContentPage from '../page'
+import CaseStudyOverview from './CaseStudyOverview';
 import useOukapi from '../../helpers/dataFetch';
 const BASE_URL = process.env.REACT_APP_BASE_URL;
 const CASE_STUDIES_LANDING_PAGE = process.env.REACT_APP_CASE_STUDIES_LANDING_PAGE;
+const CASE_STUDIES = process.env.REACT_APP_CASE_STUDIES;
 
 const CaseStudiesLandingPage = ({styleName}) => {
   const [title, setTitle] = useState("");
   const [introParagraph, setIntroParagraph] = useState("");
 
-  const [{data}, isError] = useOukapi(new URL(CASE_STUDIES_LANDING_PAGE, BASE_URL).href);
+  let data, caseStudiesData, isError;
+  [{data}, isError] = useOukapi(new URL(CASE_STUDIES_LANDING_PAGE, BASE_URL).href);
+  [caseStudiesData, isError] = useOukapi(new URL(CASE_STUDIES, BASE_URL).href);
 
   useEffect(() => {
     if (data.hasOwnProperty("title") && data.hasOwnProperty("introParagraph") ) {
@@ -16,12 +20,19 @@ const CaseStudiesLandingPage = ({styleName}) => {
       setIntroParagraph(data.introParagraph)
     }
   }, [data]);
-  
-  if (isError || !data) return <h1>404 - content not found!</h1>;
+
+  if (isError || !data || !caseStudiesData) return <h1>404 - content not found!</h1>;
+
+  const caseStudyOverviewElements = caseStudiesData.data.map(caseStudy => {
+    return <CaseStudyOverview {...caseStudy} key={caseStudy.id}  />
+  });
 
   return (
     <main className={styleName}>
       <ContentPage title={`<h1>${title}</h1>`} introParagraph={introParagraph} />
+      <ul>
+        {caseStudyOverviewElements}
+      </ul>
     </main>
   )
 }

--- a/src/components/genericcontentpage/GenericContentPage.js
+++ b/src/components/genericcontentpage/GenericContentPage.js
@@ -5,7 +5,6 @@ const BASE_URL = process.env.REACT_APP_BASE_URL;
 
 const GenericContentPage = ({match}) => {
   const {slugField} = match.params;
-console.log(BASE_URL);
   const [{ data, isError }] = useOukapi(new URL('/pages?slugfield='+slugField, BASE_URL).href);
 
   if (isError || !data[0]) return <h1>404 - content not found!</h1>;

--- a/src/styles/css/styles.css
+++ b/src/styles/css/styles.css
@@ -607,6 +607,14 @@ footer a {
     width: 25%;
     padding: 30px;
   }
+
+  /* temp styles - please let's re-factor this: */
+  .case-study-overview {
+    background-color: #e6e6e6;
+    flex: 1 1 auto;
+    margin-bottom: 20px;
+    padding: 30px;
+  }
 }
 
 @media only screen and (min-width: 64em) {


### PR DESCRIPTION
This PR:

- Fetches the Case Study Landing Page content and renders to `/case-studies`
- Fetches Case Studies themselves and renders their title + description to `/case-studies`
- Fetches an individual case study and renders to `/case-studies/:some-slug`

... still in progress as of end of play Tuesday 20th April, sorry! I'm in some kind of infinite fetch scenario, I'll look with fresh eyes tomorrow morning 👀 