### PR TITLE
Fixes manifest error in console

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,23 +1,7 @@
 {
   "short_name": "React App",
   "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
+  "icons": [],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",


### PR DESCRIPTION
Small PR to remove the default icons from `create-react-app` from the app's `manifest.json`. This was previously erroring in the console (see below), but is not anymore:

![image](https://user-images.githubusercontent.com/20354076/115721228-c1089b80-a375-11eb-92f1-63c35c822995.png)
