### PR TITLE
Render page title on Contact and About pages

### DIFF
--- a/src/components/about/index.js
+++ b/src/components/about/index.js
@@ -6,7 +6,7 @@ import HtmlSection from '../htmlsection';
 import LinksList from '../links/LinksList';
    
 const About = ({aboutProps, styleName}) => {
-    const {article: {sections }} = aboutProps;
+    const {article: { title, sections }} = aboutProps;
     
     const [sectionHeadings, setSectionHeadings] = useState([]);
     useEffect(() => {
@@ -18,6 +18,7 @@ const About = ({aboutProps, styleName}) => {
        
        <>
         <main className={styleName}>
+            <h1>{title}</h1>
             <div className="flexcontainer">
             <SideMenu subMenu={sectionHeadings} />
           

--- a/src/components/contact/index.js
+++ b/src/components/contact/index.js
@@ -4,7 +4,7 @@ import LinksList from '../links/LinksList'
 import SideMenu from '../sidemenu';
 
 const Contact = ({contactProps, styleName}) => {
-  const {contactUs: { sections, ReadNextLink }} = contactProps;
+  const {contactUs: { title, sections, ReadNextLink }} = contactProps;
   const [sectionHeadings, setSectionHeadings] = useState([]);
 
   useEffect(() => {
@@ -14,6 +14,7 @@ const Contact = ({contactProps, styleName}) => {
   return (
     <>
       <main className={styleName}>
+        <h1>{title}</h1>
         <div className="flexcontainer">
           
           <SideMenu subMenu={sectionHeadings} />


### PR DESCRIPTION
Some work that would ideally be completed by re-factoring `Contact`, `About` and `GenericContentPage` components in order for all article-type pages to use `GenericContentPage`.... but for now, this was a very quick fix!