### PR TITLE
Logo links to home page

### DIFF
--- a/src/components/banner/index.js
+++ b/src/components/banner/index.js
@@ -1,8 +1,10 @@
+import { Link } from "react-router-dom";
+
 const Banner = () => {
 
 return (
 <div className="banner">
-    <a href="#0">Openreferral UK</a>
+    <Link to="/">Openreferral UK</Link>
     <a href="/documentation-and-tools" className="oruktools">
         Document &amp; Tools
     </a>

--- a/src/components/banner/index.js
+++ b/src/components/banner/index.js
@@ -4,7 +4,8 @@ const Banner = () => {
 
 return (
 <div className="banner">
-    <Link to="/">Openreferral UK</Link>
+    {/* TODO: this Link should be an image instead of text */}
+    <Link to="/">Open Referral UK</Link>
     <a href="/documentation-and-tools" className="oruktools">
         Document &amp; Tools
     </a>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,10 +1,11 @@
+import { Link } from "react-router-dom";
 
 const Header = () => {
 
   return (
     <header className="header">
       <div className="parent">
-        <a href="#0"><img src="/OpenReferralUK.png" alt="Open referral logo"></img></a>
+        <Link to="/"><img src="/OpenReferralUK.png" alt="Open referral logo"/></Link>
         <a href="/documentation-and-tools" className="oruktools">
           Document &amp; Tools
         </a>


### PR DESCRIPTION
- Header logo converted to `react-router-dom` `Link` component
- Header logo link now correctly targets home route
- Footer app title text link converted to `react-router-dom` `Link` component
- **TODO** added in the footer about adding the logo in here - I'll create a new issue about this in the github sprint project