### PR TITLE
Scroll to top on link click

### DIFF
--- a/src/components/navigator/ScrollToTop.js
+++ b/src/components/navigator/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  
+  useEffect(() => {
+    window.scrollTo({top: 0, left: 0});
+  }, [pathname]);
+
+  return null;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import ScrollToTop from './components/navigator/ScrollToTop';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 ReactDOM.render(
   <React.StrictMode>
     <Router>
-    <App />
+      <ScrollToTop/>
+      <App />
     </Router>
   </React.StrictMode>,
   


### PR DESCRIPTION
This PR:
- Implements a new component called `ScrollToTop` and implements this part of the router at highest level (`index.js`)
- It is intended behaviour that all (internal) links, when clicked on, will navigate to the top of the target page component

Closes [issue #132 in human services repo](https://github.com/WeAreSnook/human-services/issues/132) if merged