### PR TITLE
Render H1 inside article on all content-style pages

### DIFF
--- a/src/components/about/index.js
+++ b/src/components/about/index.js
@@ -18,15 +18,15 @@ const About = ({aboutProps, styleName}) => {
        
        <>
         <main className={styleName}>
-            <h1>{title}</h1>
             <div className="flexcontainer">
             <SideMenu subMenu={sectionHeadings} />
           
             <article className="flexright">     
-            <HtmlSection sections={sections} /> 
+                <h1>{title}</h1>
+                <HtmlSection sections={sections} /> 
                 
                 <hr/>
-        {/*pass to Leftright */}
+                {/*pass to Leftright */}
                 <LinksList list={[{id:1, url:"/apage", TextToDisplay:"How Open Referral UK works"}]} />
             </article>
             </div>     

--- a/src/components/casestudies/CaseStudy.js
+++ b/src/components/casestudies/CaseStudy.js
@@ -30,13 +30,13 @@ const CaseStudy = ({ match }) => {
 
   return (
     <main className="main">
-      <h1>{title}</h1>
       <div className="flexcontainer">
         <SideMenu subMenu={sectionHeadings} />
-        <div className="flexright">
+        <article className="flexright">
+          <h1>{title}</h1>
           <HtmlSection sections={sections} />
           {readNextLink}
-        </div>
+        </article>
       </div>
     </main>
   )

--- a/src/components/contact/index.js
+++ b/src/components/contact/index.js
@@ -14,12 +14,12 @@ const Contact = ({contactProps, styleName}) => {
   return (
     <>
       <main className={styleName}>
-        <h1>{title}</h1>
         <div className="flexcontainer">
           
           <SideMenu subMenu={sectionHeadings} />
 
           <article className="flexright">
+            <h1>{title}</h1>
 
             <HtmlSection sections={sections} />
 

--- a/src/components/genericcontentpage/GenericContentPage.js
+++ b/src/components/genericcontentpage/GenericContentPage.js
@@ -35,10 +35,10 @@ const GenericContentPage = ({ match }) => {
 
   return (
     <main className="main">
-      <h1>{page.title}</h1>
       <div className="flexcontainer">
         <SideMenu subMenu={sectionHeadings} />
         <article className="flexright">
+          <h1>{page.title}</h1>
           <HtmlSection sections={page.sections} />
           {readNextLink}
         </article>


### PR DESCRIPTION
Previously, content pages were rendering H1 as the first child of the `<main>` element - on Ananda's suggestion, these have been moved inside the `<article>`. This affects the following pages:

- About ORUK
- Features of the standard
- Steps to adoption
- Individual case study
- Contact