### PR TITLE
Routes for Accessibility Statement, Privacy Policy and Ts&Cs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,6 +77,9 @@ const footerProps = data;
             <Route path="/community" render={() =>  <CommunityPage communityProps={communityProps} styleName="main"/> }/>
             <Route path="/contact-us" render={() => <GenericContentPage cmsLocation={CONTACT_PAGE} articleType="contactUs" />} />
             <Route path="/who-is-using" render={() =>  <WhoIsUsing styleName="main"/> }/>
+            <Route path="/accessibility-statement" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />
+            <Route path="/privacy-policy" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />
+            <Route path="/terms-conditions" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />
             <Route path="/show-error"  component={GenericErrorPage} />
             <Route path="/404"  component={NotFound} />
             <Redirect to="/404" />


### PR DESCRIPTION
Small PR to render generic content pages for Accessibility Statement, Privacy Policy and Ts&Cs on the following routes:
- `/accessibility-statement`
- `/privacy-policy`
- `terms-conditions`