### PR TITLE
"Who's Using?" page refactor

### DIFF
--- a/src/components/shared/title/index.js
+++ b/src/components/shared/title/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 
 
-const Title = ({title, id}) => {
+const Title = ({title, id, }) => {
 
-    return <h2 key={id}>{title}</h2>
+    return <h2 id={id}>{title}</h2>
 
 }
 

--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -9,7 +9,7 @@ const SideMenu = ({ subMenu }) => {
 		//TO DO select the active sub menu item probably based off the URL passed to the API
 
 		<>
-			<div className="sidebar flex-left">
+			<aside className="sidebar flex-left">
 				<h4 className="sidebar__heading">On this page</h4>
 				<ul>
 					{subMenu.map( (menuItem, index) => {
@@ -22,7 +22,7 @@ const SideMenu = ({ subMenu }) => {
 						)
 					})}
 				</ul>
-			</div>
+			</aside>
 		</>
 	)
 }

--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -11,17 +11,19 @@ const SideMenu = ({ subMenu }) => {
 		<>
 			<aside className="sidebar flex-left">
 				<h4 className="sidebar__heading">On this page</h4>
-				<ul>
-					{subMenu.map( (menuItem, index) => {
-						return (
-							<li key={index}>
-								<AnchorLink href={`#section-${index+1}-heading`}>
-									{menuItem}
-								</AnchorLink>
-							</li>
-						)
-					})}
-				</ul>
+				<nav>
+					<ul>
+						{subMenu.map((menuItem, index) => {
+							return (
+								<li key={index}>
+									<AnchorLink href={`#section-${index + 1}-heading`}>
+										{menuItem}
+									</AnchorLink>
+								</li>
+							)
+						})}
+					</ul>
+				</nav>
 			</aside>
 		</>
 	)

--- a/src/components/whoisusing/LinkWithTitleSection.js
+++ b/src/components/whoisusing/LinkWithTitleSection.js
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+
+const LinkWithTitle = ({title, link: { url, TextToDisplay } }) => {
+  if (!title || !url || !TextToDisplay) return null;
+
+  return (
+    <>
+      <hr />
+      <section>
+        <h3>{title}</h3>
+        <Link to={url}>
+          {TextToDisplay}
+        </Link>
+      </section>
+    </>
+  )
+}
+
+export default LinkWithTitle;

--- a/src/components/whoisusing/index.js
+++ b/src/components/whoisusing/index.js
@@ -31,10 +31,34 @@ const WhoIsUsing = () => {
     const REACT_APP_WHO_IS_USING_PAGE = process.env.REACT_APP_WHO_IS_USING_PAGE;
 
     const [{ data, isError }, isFetching] = useOukapi(`${BASE_URL}${REACT_APP_WHO_IS_USING_PAGE}`);
-    const { pageTitle, numbers, id, orgSections, caseStudiesLink, underNumbersText, registerLink } = data
+    const {
+        pageTitle, 
+        numbers, 
+        id, 
+        orgSections, 
+        caseStudiesLink, 
+        underNumbersText, 
+        registerLink,
+        registerLinkWithTitle
+     } = data
 
     //need id make sure all keys set
     console.log(id);
+
+    let registerLinkWithTitleSection = null;
+    if (registerLinkWithTitle) {
+        registerLinkWithTitleSection = (
+        <>
+            <hr/>
+            <section>
+                <h3>{registerLinkWithTitle.title}</h3>
+                <Link to={registerLinkWithTitle.link.url}>
+                    {registerLinkWithTitle.link.TextToDisplay}
+                </Link>
+            </section>
+        </>
+        )
+    }
 
     if (isFetching || isError) return null;
 
@@ -66,6 +90,8 @@ const WhoIsUsing = () => {
 
                     })
                     }
+
+                    {registerLinkWithTitleSection}
 
                 </article>
 

--- a/src/components/whoisusing/index.js
+++ b/src/components/whoisusing/index.js
@@ -1,21 +1,20 @@
-import Button from '../shared/button';
+import { Fragment } from 'react';
+import { Link } from 'react-router-dom';
 import Numbers from './badge/'
 import SideMenu from "../sidemenu/";
 import useOukapi from '../../helpers/dataFetch';
 import CardList from './Cards/CardList';
-import LinksList from '../links/LinksList';
-import { Fragment } from 'react';
 import Title from '../shared/title';
 
 //build a picture
- const WhoIsUsing= ({ styles, disabled }) => {
+const WhoIsUsing = () => {
 
- //use styles prop
+    //use styles prop
 
     const getObjects = (orgSections) => {
-       
+
         let titles = orgSections.filter(org => org.title);
-       
+
         return titles.map(title => {
             return title.title
         });
@@ -28,60 +27,52 @@ import Title from '../shared/title';
 
     }
 
-
-    const handleClick = (event) => {
-        console.log("Button clicked,  define handler");
-    }
-
     const BASE_URL = process.env.REACT_APP_BASE_URL;
     const REACT_APP_WHO_IS_USING_PAGE = process.env.REACT_APP_WHO_IS_USING_PAGE;
 
-    const [{data, isError}, isFetching] = useOukapi(`${BASE_URL}${REACT_APP_WHO_IS_USING_PAGE}`);
-    const {pageTitle, numbers, id, orgSections, caseStudiesLink, underNumbersText } = data
+    const [{ data, isError }, isFetching] = useOukapi(`${BASE_URL}${REACT_APP_WHO_IS_USING_PAGE}`);
+    const { pageTitle, numbers, id, orgSections, caseStudiesLink, underNumbersText, registerLink } = data
 
-
-    const label = "Register your organisation"; //check if comes through from backend
-    console.log("data", data) //check no unnecessary update
-  
     //need id make sure all keys set
     console.log(id);
- 
+
+    if (isFetching || isError) return null;
+
     return (
-        !isFetching && !isError &&  (<main id="content" className="main">
-            
-          
-              <div className="flexcontainer">
-            <SideMenu subMenu={getObjects(orgSections)} />
-            <div className="flex-right">
-        <h1>{pageTitle}</h1>
-        <p>{underNumbersText}</p>
-      
-       <Numbers  numbers={numbers} />
-       
-        <Button label={label} disabled={disabled} onClick={handleClick} styles="style" role="button" icon="label" />
-       
-        { caseStudiesLink && <ul className="listnostyle tempstyle"><LinksList list={caseStudiesLink} /></ul> }
+        <main id="content" className="main-container">
+            <div className="page-container flex-container">
+                <SideMenu subMenu={getObjects(orgSections)} />
+                <article className="flex-right">
+                    <h1>{pageTitle}</h1>
 
-         
-         
-                { orgSections &&  getGroups(orgSections).map(organisation => 
-                    {
-                        return <Fragment key={`${organisation.id}grouptitle}`}> 
-                            <Title title={organisation.title}/>  
-                         <div id={`${organisation.id}_title`} className="cardgrid">
-                        <CardList key={organisation.id} organisationList={organisation.Organisation} type="org" />
-                        </div>
+                    <Numbers numbers={numbers} />
+                    <p>{underNumbersText}</p>
+
+                    <a href={registerLink.url} className="button button-primary">
+                        {registerLink.TextToDisplay}
+                    </a>
+
+                    <Link to={caseStudiesLink.url} >{caseStudiesLink.TextToDisplay}</Link>
+
+
+
+                    {orgSections && getGroups(orgSections).map((organisation, index) => {
+                        return <Fragment key={`${organisation.id}grouptitle}`}>
+                            <Title title={organisation.title} id={`section-${index + 1}-heading`} />
+                            <div id={`${organisation.id}_title`} className="cardgrid">
+                                <CardList key={organisation.id} organisationList={organisation.Organisation} type="org" />
+                            </div>
                         </Fragment>
-                      
+
                     })
-            }
-            
-         </div>
+                    }
 
-    </div>
+                </article>
 
-</main>)
-)
+            </div>
+
+        </main>
+    )
 
 }
 export default WhoIsUsing;

--- a/src/components/whoisusing/index.js
+++ b/src/components/whoisusing/index.js
@@ -5,6 +5,7 @@ import SideMenu from "../sidemenu/";
 import useOukapi from '../../helpers/dataFetch';
 import CardList from './Cards/CardList';
 import Title from '../shared/title';
+import LinkWithTitleSection from "./LinkWithTitleSection";
 
 //build a picture
 const WhoIsUsing = () => {
@@ -45,21 +46,6 @@ const WhoIsUsing = () => {
     //need id make sure all keys set
     console.log(id);
 
-    let registerLinkWithTitleSection = null;
-    if (registerLinkWithTitle) {
-        registerLinkWithTitleSection = (
-        <>
-            <hr/>
-            <section>
-                <h3>{registerLinkWithTitle.title}</h3>
-                <Link to={registerLinkWithTitle.link.url}>
-                    {registerLinkWithTitle.link.TextToDisplay}
-                </Link>
-            </section>
-        </>
-        )
-    }
-
     if (isFetching || isError) return null;
 
     return (
@@ -91,7 +77,7 @@ const WhoIsUsing = () => {
                     })
                     }
 
-                    {registerLinkWithTitleSection}
+                    <LinkWithTitleSection {...registerLinkWithTitle}/>
 
                 </article>
 


### PR DESCRIPTION
Some quite significant changes to the 'Who's Using?' page:
- basic styling (e.g. sidebar on the side)
- sidebar internal links now working
- render "register" link at top of page from CMS
- renders the "register" link with title at the bottom of the page from CMS

Plus some general quality of life improvements found when completing this work:
- sidebar now in `<aside>` rather than `<div>`
- wrapping sidemenu in `<nav>` tag
- change to `<Title/>` component to assign `id` to DOM id instead of React `key` as was being done previously (doesn't appear like it was ever used)