### PR TITLE
General accessibility enhancements

### DIFF
--- a/src/components/casestudies/LandingPage.js
+++ b/src/components/casestudies/LandingPage.js
@@ -28,7 +28,7 @@ const CaseStudiesLandingPage = ({styleName}) => {
   });
 
   return (
-    <main id="content" className={styleName} role="main" aria-label="main">
+    <main id="content" className={styleName} role="main">
       <ContentPage title={`<h1>${title}</h1>`} introParagraph={introParagraph} />
       <ul>
         {caseStudyOverviewElements}

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -35,7 +35,7 @@ const Footer = ({ footerProps, styleName }) => {
 
   return (
     Object.keys(about).length > 0 &&
-    (<footer className={styleName} role="contentinfo" aria-label="footer">
+    (<footer className={styleName} role="contentinfo">
 
       <div className="page-container">
         <div className="footer__top">

--- a/src/components/footer/LinkExternal.js
+++ b/src/components/footer/LinkExternal.js
@@ -5,8 +5,8 @@ const LinkExternal = ({link, target, styleName}) =>  {
 
     let rel = target && target === "_blank" ? "noreferrer noopener" : "";
 
-    let anchorLink = rel.length > 0? <a aria-label={link.labelText} href={link.url} rel={rel} target={target} className={styleName}>{link.TextToDisplay}</a>
-    : <a aria-label={link.labelText} href={link.url} target={target} className={styleName}>{link.TextToDisplay}</a>
+    let anchorLink = rel.length > 0? <a href={link.url} rel={rel} target={target} className={styleName}>{link.TextToDisplay}</a>
+    : <a href={link.url} target={target} className={styleName}>{link.TextToDisplay}</a>
       
   return (
       <>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -22,7 +22,10 @@ const Header = ({ mainMenu, topMenuId }) => {
     <header className="global-header" role="banner" aria-label="Header">
       <div className="global-header__top-container page-container">
         <Link to="/" className="global-header__logo"><img src={logo} alt="Open Referral UK"/></Link>
-        <button onClick={toggleClass} className={isActive ? 'button button-secondary button-header hide-md active': "button button-secondary button-header hide-md"}>
+        <button onClick={toggleClass} 
+                className={isActive ? 'button button-secondary button-header hide-md active': "button button-secondary button-header hide-md"}
+                aria-label={isActive ? 'menu open' : 'menu closed'}
+        >
           <svg width="20" height="15" viewBox="0 0 20 15" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M20 0H0V3H20V0Z" fill="#135E75" />
             <path d="M20 6H0V9H20V6Z" fill="#135E75" />

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -19,7 +19,7 @@ const Header = ({ mainMenu, topMenuId }) => {
   };
 
   return (
-    <header className="global-header" role="banner" aria-label="Header">
+    <header className="global-header" role="banner">
       <div className="global-header__top-container page-container">
         <Link to="/" className="global-header__logo"><img src={logo} alt="Open Referral UK"/></Link>
         <button onClick={toggleClass} 

--- a/src/components/links/LinksList.js
+++ b/src/components/links/LinksList.js
@@ -15,7 +15,7 @@ const LinksList = ({list}) => {
 					list.id  !== "" ?
 					  list && !list.external ?
 						( <li key={list.id}>
-						 <Link aria-label={list.labelText} to={list.url}>
+						 <Link to={list.url}>
 								{list.TextToDisplay}
 							</Link>
 						</li> ) : (

--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -10,7 +10,7 @@ const SideMenu = ({ subMenu }) => {
 
 		<>
 			<div className="sidebar flex-left">
-				<h4 className="sidebar__heading">On this page</h4>
+				<h2 className="sidebar__heading">On this page</h2>
 				<ul>
 					{subMenu.map( (menuItem, index) => {
 						return (

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -416,6 +416,7 @@ footer {
 
   .sidebar__heading {
     font-size: 0.875rem;
+    line-height: 1.8;
   }
 
   ul {

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -446,6 +446,7 @@ footer {
 
     a {
       color: white;
+      display: block;
     }
     
   }


### PR DESCRIPTION
- Updates content page's sidemenu 'On This Page' heading from h4 to h2
- adds menu open/closed aria label to mobile menu button
- adds `display: block;` to elements that match the selector `footer ul li a`. This allows clickable area when link falls on to multiple lines
- removed unnecessary aria labels from `<header/>` and `<footer/>` tags
- removes aria-labels from links. From Usman: _"It is unneccessary for all links to have aria-labels duplicating the content, it is the textual content that is sufficient and will be read by screenreaders."_