### PR TITLE
Fixes 'for developers' link on mobile

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -33,12 +33,9 @@ const Header = ({ mainMenu, topMenuId }) => {
           </svg>
           {isActive ? 'Close': "Menu"}
         </button>
-        {/* <a href="/developers" className="button button-secondary button-header show-md">
-          For developers
-        </a> */}
         <LinkExternal link={link} rel="noreferrer" styleName="button button-secondary button-header show-md" />
       </div>
-      <Navigator onClick={toggleClass} mainMenu={mainMenu} topMenuId={topMenuId.toString()} menuButton={isActive} />
+      <Navigator onClick={toggleClass} mainMenu={mainMenu} topMenuId={topMenuId.toString()} menuButton={isActive} developersLink={link}/>
     </header>
   );
 }

--- a/src/components/navigator/Navigator.js
+++ b/src/components/navigator/Navigator.js
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
 import { PropTypes } from 'prop-types';
+import LinkExternal from '../footer/LinkExternal';
 
-const Navigator = ({mainMenu, topMenuId, menuButton, onClick}) => {
+const Navigator = ({mainMenu, menuButton, onClick, developersLink}) => {
   const isLongestMatch = (mainMenu, index) => {
     if (window.location.href.indexOf(mainMenu[index].link) === -1)
     {
@@ -37,9 +38,7 @@ const Navigator = ({mainMenu, topMenuId, menuButton, onClick}) => {
     
     <nav onClick={onClick} className={menuButton ? 'global-nav--open global-nav': "global-nav"}>
       <div className="page-container">
-        <a href="/developers" className="button button-secondary button-header hide-md">
-          For developers
-        </a>
+        <LinkExternal link={developersLink} rel="noreferrer" styleName="button button-secondary button-header hide-md" />
         <ul>
             {menuItems}
         </ul>


### PR DESCRIPTION
The 'For developers' link in the header was not working on mobile (was giving 404). The data that was being rendered to the screen was different in this case from the link rendered on desktop.

The link rendered on mobile now uses the same single source of truth for link data as the desktop.