### PR TITLE
Style fix/typography fixes

### DIFF
--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -280,6 +280,10 @@ main article { // article page content, pulled from CMS
     margin-top: 1em;
   }
 
+  h4 {
+    margin-top: 1em;
+  }
+
   blockquote { // for content quotes
     margin: $padMedium 0;
   }

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -31,10 +31,6 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $boldWeight;
 }
 
-p, a, li, h1, h2, h3, h4, h5, h6 {
-  max-width: 60em;
-}
-
 h1 {
   font-size: 1.75rem;
   line-height: 1.3;


### PR DESCRIPTION
Removes a `max-width` added to some typography HTML tags, is now replaced with the `.format` class.

Also add a `margin-top` for `h4`'s which was missing. 