### PR TITLE
Stops SideMenu rendering if there is only one section with no title on a content page

### DIFF
--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -1,7 +1,8 @@
 import AnchorLink from 'react-anchor-link-smooth-scroll';
 
 const SideMenu = ({ subMenu }) => {
-	if (!subMenu || subMenu.length === 0) {
+	// don't render sidebar unless we have at least one section that has a title
+	if (!subMenu || subMenu.length === 0 || (subMenu.length === 1 && subMenu[0] === "")) {
 		return null;
 	}
 


### PR DESCRIPTION
Stops SideMenu rendering if there is only one section with no title on a content page.

The purpose of this is to not render a SideMenu on the 'Contact Us' page:

![image](https://user-images.githubusercontent.com/20354076/117156956-169d6900-adb6-11eb-8fa1-d0c0840fad9f.png)
