### PR TITLE
Updates `who-is-using` route to be `standard-community`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,7 @@ function App() {
             <Route path="/community/case-studies" render={ () => <CaseStudiesLandingPage styleName="main"/> } />
             <Route path="/community" render={() =>  <GenericLandingPage cmsLocation={process.env.REACT_APP_COMMUNITY_PAGE} articleType="communityPage"/> }/>
             <Route path="/contact-us" render={() => <GenericContentPage cmsLocation={CONTACT_PAGE} articleType="contactUs" />} />
-            <Route path="/who-is-using" render={() =>  <WhoIsUsing styleName="main"/> }/>
+            <Route path="/standard-community" render={() =>  <WhoIsUsing styleName="main"/> }/>
             <Route path="/accessibility-statement" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />
             <Route path="/privacy-policy" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />
             <Route path="/terms-conditions" render={({ location }) => <GenericContentPage cmsLocation={`/pages?slugfield=${location.pathname.substring(1)}`} articleType="page" />} />


### PR DESCRIPTION
Tiny fix to the path to implement the breaking change from this morning (requires update to Community page content).

Request from Ann (content): https://docs.google.com/spreadsheets/d/1mP-4yTFDSQ5-miOEZ-vYqi0E-nYya0f2sOtdJobK3z0/edit?disco=AAAAMSMim54