### PR TITLE
Tiny fix to rename `class` to `className` in CaseStudyLandingPage

### DIFF
--- a/src/components/casestudies/LandingPage.js
+++ b/src/components/casestudies/LandingPage.js
@@ -28,7 +28,7 @@ const CaseStudiesLandingPage = () => {
   });
 
   return (
-    <div class="page-container">
+    <div className="page-container">
       <main id="content" className="main-container" role="main">
         <h1>{title}</h1>
         <InjectHtml paragraphText={introParagraph} />


### PR DESCRIPTION
Fixes a console error that is occurring on production:

![image](https://user-images.githubusercontent.com/20354076/117165428-65023600-adbd-11eb-8d5a-dda754fbf206.png)
