### PR TITLE
Hide SideMenu on video transcript page as well as contact us page

### DIFF
--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -2,7 +2,7 @@ import AnchorLink from 'react-anchor-link-smooth-scroll';
 
 const SideMenu = ({ subMenu }) => {
 	// don't render sidebar unless we have at least one section that has a title
-	if (!subMenu || subMenu.length === 0 || (subMenu.length === 1 && subMenu[0] === "")) {
+	if (!subMenu || subMenu.length === 0 || (subMenu.length === 1 && !subMenu[0])) {
 		return null;
 	}
 


### PR DESCRIPTION
- Looking for general falsey values and not just empty string when deciding when not to render a sidemenu on generic content page