### PR TITLE
Removes `frameborder` attribute from video `iframe`

### DIFF
--- a/src/components/shared/video/index.js
+++ b/src/components/shared/video/index.js
@@ -4,7 +4,7 @@ const Video = ({ name, width, height, source }) => {
 
     return( 
         <>
-        <iframe id="videobox" height={height} src="https://www.youtube.com/embed/dn1ryloOLvk"  title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
+        <iframe id="videobox" height={height} src="https://www.youtube.com/embed/dn1ryloOLvk"  title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
         {/* this will ideally need adding to the backend to remove hard-coding*/}
         <div id="video-link"><a href="https://openreferraluk.org/open-referral-uk-video-transcript">View the full video transcript including visual description</a></div>
         </>


### PR DESCRIPTION
Closes #165

Removes obsolete `frameborder` attribute from the `iframe` that houses the homepage video:

![image](https://user-images.githubusercontent.com/20354076/125957845-af08c369-d068-4c04-b692-a3d19124ab16.png)
