### PR TITLE
Removes 'contentinfo' role from `<footer/>` element

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -52,7 +52,7 @@ const Footer = ({ footerProps, styleName }) => {
 
   return (
     Object.keys(about).length > 0 &&
-    (<footer className={styleName} role="contentinfo">
+    (<footer className={styleName}>
 
       <div className="page-container">
         <div className="footer__top">


### PR DESCRIPTION
Closes #164 - removes unnecessary 'role' attribute from the <footer/> element.