### PR TITLE
Updates `<aside>` header ('On this page') to be H2 instead of H4

### DIFF
--- a/src/components/sidemenu/index.js
+++ b/src/components/sidemenu/index.js
@@ -11,7 +11,7 @@ const SideMenu = ({ subMenu }) => {
 
 		<>
 			<aside className="sidebar flex-left">
-				<h4 className="sidebar__heading">On this page</h4>
+				<h2 className="sidebar__heading">On this page</h2>
 				<nav>
 					<ul>
 						{subMenu.map((menuItem, index) => {


### PR DESCRIPTION
Closes #160 - updates H2 to be H4. 

No styling changes required as selectors for this heading are on the classname!
 
![image](https://user-images.githubusercontent.com/20354076/126133876-4eb95fbc-850e-4f89-bffe-7a10e22b8bda.png)
![image](https://user-images.githubusercontent.com/20354076/126133992-94f6cede-0c35-4e29-98fd-a135addd8f10.png)
