### PR TITLE
Fix/185 fix link with title on standard community

### DIFF
--- a/src/components/home/card/index.js
+++ b/src/components/home/card/index.js
@@ -22,7 +22,15 @@ const CardList = ({  id, itemList,  styles }) => {
         addPadding();
         const logosHolder = list.map(item => {
             if (item.CompanyLogo) {
-            return <li  key={item.id ? `${item.id}_itemcard` : ""} className="img"><a href={item.link} className="link-with-image"><ImageCard  id={id}  logo={item}   styleName=""/></a></li>
+                return (
+                    <li 
+                        key={item.id ? `${item.id}_itemcard` : ""} 
+                        className="img">
+                        <a href={item.link} className="link-with-image" aria-label={item.CompanyLogo.caption}>
+                            <ImageCard  id={id}  logo={item}   styleName=""/>
+                        </a>
+                    </li>
+                )
             } else {
                 return <li key={i++} className="img"></li>
             }

--- a/src/components/whoisusing/LinkWithTitleSection.js
+++ b/src/components/whoisusing/LinkWithTitleSection.js
@@ -1,13 +1,13 @@
 import LinkExternal from '../footer/LinkExternal';
 
-const LinkWithTitle = ({ link }) => {
+const LinkWithTitle = ({ link, title }) => {
   if (!link) return null;
 
   return (
     <>
       <hr />
       <section>
-      {link.TextToDisplay && <h3>{link.TextToDisplay}</h3> }
+      {link.TextToDisplay && <h3>{title}</h3> }
         <p>
           <LinkExternal link={link} styleName=""/> 
           </p>


### PR DESCRIPTION
Closes #185.

Correctly formats the `LinkWithTitle` component at the bottom of the '/standard-community', 'Who's Using ORUK?' page. This involved rendering the correct property for the link title from CMS (previously: title and link both rendered the same text). This will address the inaccurate text label for the link mentioned in issue #185.

This is in-keeping with [the designs for the website](https://www.figma.com/proto/2xrZWgoxb0vgylFFbimESB/ORUK-page-designs?node-id=191%3A2658&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=103%3A0).