### PR TITLE
Fix 'Skip to content' link for pages that are not the home page

### DIFF
--- a/src/components/header/SkipToContent.js
+++ b/src/components/header/SkipToContent.js
@@ -1,6 +1,8 @@
+import { Link } from "react-router-dom"
+
 const SkipToContent = () => {
   return (
-      <a href="#content" className="skiplink">Skip to main content</a>
+      <Link to="#content" className="skiplink">Skip to main content</Link>
   )
 };
 


### PR DESCRIPTION
Closes #172 by replacing the Skip To Content component's anchor tag with a `<Link>` from the `react-router-dom` package.