### PR TITLE
Fixes misaligned 'forum' button in header on medium screens

### DIFF
--- a/src/styles/sass/_md.scss
+++ b/src/styles/sass/_md.scss
@@ -6,6 +6,10 @@
   .global-header__top-container {
     border-bottom: none;
   }
+
+  .forum-link.show-md {
+    margin-bottom: initial;
+  }
 }
 
 .global-nav {


### PR DESCRIPTION
Closes #192 - removes margin-bottom on medium size screens for 'forum' button in header.

![image](https://user-images.githubusercontent.com/20354076/126648713-4cf7201a-5ce8-41c8-b9e6-59904ba46717.png)
