### PR TITLE
Improves keyboard accessibility for dashboard modal

### DIFF
--- a/src/components/dashboard/summaryButton.js
+++ b/src/components/dashboard/summaryButton.js
@@ -7,15 +7,21 @@ const SummaryButton = ({ summary }) => {
     if (!summary)
         return <span>-</span>;
 
-    return <>
-        <button className='button-link' onClick={() => setIsOpen(true)}>Read</button>
-        <div className={`modal-background ${isOpen ? 'visible' : ''}`}>
-            <div className='modal'>
-                <button className='close-button button-link' onClick={() => setIsOpen(false)}>×</button>
-                {summary}
-            </div>
+    return (
+      <>
+        <button className="button-link" onClick={() => setIsOpen(true)}>
+          Read
+        </button>
+        <div className={`modal-background ${isOpen ? "visible" : ""}`}>
+          <div className={`modal ${isOpen ? "visible" : ""}`}>
+            <button className="close-button button-link" onClick={() => setIsOpen(false)}>
+              ×
+            </button>
+            {summary}
+          </div>
         </div>
-    </>;
+      </>
+    );
 };
 
 export default SummaryButton;

--- a/src/components/dashboard/summaryButton.js
+++ b/src/components/dashboard/summaryButton.js
@@ -13,7 +13,7 @@ const SummaryButton = ({ summary }) => {
           Read
         </button>
         <div className={`modal-background ${isOpen ? "visible" : ""}`}>
-          <div className={`modal ${isOpen ? "visible" : ""}`}>
+          <div className={`modal ${isOpen ? "visible" : ""}`} role="dialog" aria-modal="true">
             <button className="close-button button-link" onClick={() => setIsOpen(false)}>
               ×
             </button>

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -1137,7 +1137,13 @@ th:last-child {
   .modal {
     position: relative;
 
-    display: block;
+    // display:none;-ing the modal until visible prevents screenreader and 
+    // keyboard-only users from focusing on the modal's close button too soon.
+    display: none;
+
+    &.visible {
+      display: block
+    }
 
     background-color: white;
     min-height: 2rem;


### PR DESCRIPTION
Closes #188 
- Prevents the dashboard modal from being closed before opened for screenreader and keyboard only users
- Adds `role` and `aria-modal` attributes to the dashboard modal to prevent navigation to content _behind_ the modal until it is closed.