### PR TITLE
Adds scope=col to `th` cells (dashboard table)

### DIFF
--- a/src/components/dashboard/table.js
+++ b/src/components/dashboard/table.js
@@ -1,23 +1,45 @@
 import Row from './row';
 import Title from './title';
 
-const Table = ({ data, help }) => <table className="feeds">
+const Table = ({ data, help }) => (
+  <table className="feeds">
     <thead>
-        <tr>
-            <th><Title help={help}>Organisation</Title></th>
-            <th><Title help={help}>Developer</Title></th>
-            <th><Title help={help}>Endpoint up</Title></th>
-            <th><Title help={help}>Services feed</Title></th>
-            <th><Title help={help}>{`Service {id} feed`}</Title></th>
-            <th><Title help={help}>Searchable</Title></th>            
-            <th><Title help={help}>Last checked</Title></th>
-            <th><Title help={help}>Summary</Title></th>
-            <th><Title help={help}>Explore</Title></th>
-        </tr>
+      <tr>
+        <th scope="col">
+          <Title help={help}>Organisation</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Developer</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Endpoint up</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Services feed</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>{`Service {id} feed`}</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Searchable</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Last checked</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Summary</Title>
+        </th>
+        <th scope="col">
+          <Title help={help}>Explore</Title>
+        </th>
+      </tr>
     </thead>
     <tbody>
-        {data.map(item => <Row key={item.url} item={item} />)}
+      {data.map((item) => (
+        <Row key={item.url} item={item} />
+      ))}
     </tbody>
-</table>;
+  </table>
+);
 
 export default Table;


### PR DESCRIPTION
**Maybe** closes #186 .

More info in the issue - but the long and short of it is I've added `scope="col"` attribute to header cells in the dashboard table to aid screenreader users.