### PR TITLE
Cookie banner colour contrast improvements

### DIFF
--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -1244,6 +1244,10 @@ button {
 
   a {
     color: inherit;
+
+    &:focus {
+      color: initial;
+    }
   }
 
   #cookietextwrapper {

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -1264,7 +1264,7 @@ button {
 
     &:hover {
       background-color: #0f4c5e;
-      border: 0;
+      border-color: #2a3834;
       color: #ffd152;
       -webkit-text-fill-color: #ffd152;
       cursor: pointer;

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -1261,18 +1261,18 @@ button {
     &:focus {
       outline: 0;
       text-decoration: none;
-      background-color: #ffd152;
-      color: #2a3834;
-      border-color: #2a3834;
+      background-color: $color-highlight;
+      color: $color-text;
+      border-color: $color-text;
     }
 
     &:hover {
-      background-color: #0f4c5e;
-      border-color: #2a3834;
-      color: #ffd152;
-      -webkit-text-fill-color: #ffd152;
+      background-color: $color-blue-darker;
+      border-color: $color-text;
+      color: $color-highlight;
+      -webkit-text-fill-color: $color-highlight;
       cursor: pointer;
-      box-shadow: 0px 0px 0px 4px #ffd152;
+      box-shadow: 0px 0px 0px 4px $color-highlight;
       text-decoration: none;
     }
   }

--- a/src/styles/sass/_sm-default.scss
+++ b/src/styles/sass/_sm-default.scss
@@ -1253,6 +1253,24 @@ button {
   #rejectTracking {
     border: 3px solid $color-white;
     background-color: $color-brand-darker;
+
+    &:focus {
+      outline: 0;
+      text-decoration: none;
+      background-color: #ffd152;
+      color: #2a3834;
+      border-color: #2a3834;
+    }
+
+    &:hover {
+      background-color: #0f4c5e;
+      border: 0;
+      color: #ffd152;
+      -webkit-text-fill-color: #ffd152;
+      cursor: pointer;
+      box-shadow: 0px 0px 0px 4px #ffd152;
+      text-decoration: none;
+    }
   }
 
   .cookiemessage {

--- a/src/styles/sass/_variables.scss
+++ b/src/styles/sass/_variables.scss
@@ -5,7 +5,7 @@ $boldWeight: 600;
 
 $color-brand: #5ac09e;
 $color-brand-lighter: lighten($color-brand, 33.333%);
-$color-brand-20: rgba(90, 192, 158, 0.2); // brand at 20% opacity
+$color-wbrand-20: rgba(90, 192, 158, 0.2); // brand at 20% opacity
 $color-brand-dark: #418f76;
 $color-brand-darker: #28614f; // AA on page-bg
 $color-text: #2a3834; // body text // AAA on page-bg

--- a/src/styles/sass/_variables.scss
+++ b/src/styles/sass/_variables.scss
@@ -5,7 +5,7 @@ $boldWeight: 600;
 
 $color-brand: #5ac09e;
 $color-brand-lighter: lighten($color-brand, 33.333%);
-$color-wbrand-20: rgba(90, 192, 158, 0.2); // brand at 20% opacity
+$color-brand-20: rgba(90, 192, 158, 0.2); // brand at 20% opacity
 $color-brand-dark: #418f76;
 $color-brand-darker: #28614f; // AA on page-bg
 $color-text: #2a3834; // body text // AAA on page-bg


### PR DESCRIPTION
Closes #181.

- `:hover` and `:focus` styles for the 'reject cookies' button have been updated to match the rest of the site / comply to colour contrast guidance
- 'View cookies' link focus state is brought into line with the rest of the site

![image](https://user-images.githubusercontent.com/20354076/126766960-8078800e-d6c5-4ca7-b14f-47d8fc2124ae.png)
![image](https://user-images.githubusercontent.com/20354076/126767009-766adcdf-209f-4f9f-a585-660f9e19e83a.png)
