### PR TITLE
Add padding to nav links

### DIFF
--- a/src/styles/sass/_lg.scss
+++ b/src/styles/sass/_lg.scss
@@ -109,7 +109,7 @@ blockquote {
 
   li a.active {
     &:after {
-      bottom: -1.1em;
+      bottom: -0.9em;
     }
   }
 }

--- a/src/styles/sass/_md.scss
+++ b/src/styles/sass/_md.scss
@@ -23,7 +23,8 @@
   }
 
   li {
-    margin: 0 15px 0 15px;
+    // margin: 0 15px 0 15px;
+    margin: 0 10px;
     list-style-type: none;
 
     &:first-child {
@@ -36,11 +37,12 @@
 
   li a {
     font-size: 1.125rem;
+    padding: 5px;
   }
 
   li a.active {
     &:after {
-      bottom: -1.3em;
+      bottom: -1em;
       border-radius: 4px 4px 0px 0px;
     }
   }

--- a/src/styles/sass/_md.scss
+++ b/src/styles/sass/_md.scss
@@ -23,7 +23,6 @@
   }
 
   li {
-    // margin: 0 15px 0 15px;
     margin: 0 10px;
     list-style-type: none;
 


### PR DESCRIPTION
Added a bit of padding top and bottom of top nav links to make it easy to click on. Removed some margin and adjusted the active link underline to keep consistent with design.

closes #170 

![image](https://user-images.githubusercontent.com/37106624/126772039-27fff73a-5693-43e8-bf88-c626e8f86f88.png)
