### PR TITLE
Remove gap between multi line links

### DIFF
--- a/src/styles/sass/_md.scss
+++ b/src/styles/sass/_md.scss
@@ -637,6 +637,10 @@ hr {
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: $padSmall;
+
+  li a {
+    display: inline-block;
+  }
 }
 
 /* ------------- HELPER CLASSES ------------- */


### PR DESCRIPTION
I have made links inside `readlinkscard` inline block to prevent the gap
This closes #176 

![image](https://user-images.githubusercontent.com/37106624/126783540-b8c1278f-8016-4939-abf2-f92d9a0f70ae.png)


